### PR TITLE
Controller app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,6 +138,7 @@ $RECYCLE.BIN/
 ### Gradle ###
 .gradle
 /build/
+/controller-app/build/
 
 # Ignore Gradle GUI config
 gradle-app.setting

--- a/controller-app/build.gradle
+++ b/controller-app/build.gradle
@@ -1,0 +1,63 @@
+plugins {
+    id "java"
+    id 'application'
+    id 'com.gradleup.shadow' version '8.3.5'
+    id "edu.wpi.first.GradleRIO" version "2025.1.1"
+    id 'edu.wpi.first.WpilibTools' version '2.1.0'
+    id 'org.openjfx.javafxplugin' version '0.1.0'
+    id "com.diffplug.spotless" version "6.12.0"
+}
+
+application {
+    mainClass = 'frc.nemesis.controller.ControllerApp'
+}
+
+wpilibTools.deps.wpilibVersion = wpi.versions.wpilibVersion.get()
+
+def nativeConfigName = 'wpilibNatives'
+def nativeConfig = configurations.create(nativeConfigName)
+
+def nativeTasks = wpilibTools.createExtractionTasks {
+    configurationName = nativeConfigName
+}
+
+nativeTasks.addToSourceSetResources(sourceSets.main)
+nativeConfig.dependencies.add wpilibTools.deps.wpilib("wpimath")
+nativeConfig.dependencies.add wpilibTools.deps.wpilib("wpinet")
+nativeConfig.dependencies.add wpilibTools.deps.wpilib("wpiutil")
+nativeConfig.dependencies.add wpilibTools.deps.wpilib("ntcore")
+nativeConfig.dependencies.add wpilibTools.deps.wpilibOpenCv("frc" + wpi.frcYear.get(), wpi.versions.opencvVersion.get())
+
+dependencies {
+    implementation wpilibTools.deps.wpilibJava("wpiutil")
+    implementation wpilibTools.deps.wpilibJava("wpimath")
+    implementation wpilibTools.deps.wpilibJava("wpinet")
+    implementation wpilibTools.deps.wpilibJava("ntcore")
+    implementation wpilibTools.deps.wpilibOpenCvJava("frc" + wpi.frcYear.get(), wpi.versions.opencvVersion.get())
+
+    implementation group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: wpi.versions.jacksonVersion.get()
+    implementation group: "com.fasterxml.jackson.core", name: "jackson-core", version: wpi.versions.jacksonVersion.get()
+    implementation group: "com.fasterxml.jackson.core", name: "jackson-databind", version: wpi.versions.jacksonVersion.get()
+
+    implementation group: "org.ejml", name: "ejml-simple", version: wpi.versions.ejmlVersion.get()
+    implementation group: "us.hebi.quickbuf", name: "quickbuf-runtime", version: wpi.versions.quickbufVersion.get();
+}
+
+// shadowJar {
+//     archiveBaseName = "TestApplication"
+//     archiveVersion = ""
+//     exclude("module-info.class")
+//     archiveClassifier.set(wpilibTools.currentPlatform.platformName)
+// }
+
+// wrapper {
+//     gradleVersion = '8.11'
+// }
+
+javafx {
+    version = "17.0.8"
+    modules = ['javafx.controls']
+}
+
+// Spotless formatting
+project.compileJava.dependsOn(spotlessApply)

--- a/controller-app/build.gradle
+++ b/controller-app/build.gradle
@@ -43,17 +43,6 @@ dependencies {
     implementation group: "us.hebi.quickbuf", name: "quickbuf-runtime", version: wpi.versions.quickbufVersion.get();
 }
 
-// shadowJar {
-//     archiveBaseName = "TestApplication"
-//     archiveVersion = ""
-//     exclude("module-info.class")
-//     archiveClassifier.set(wpilibTools.currentPlatform.platformName)
-// }
-
-// wrapper {
-//     gradleVersion = '8.11'
-// }
-
 javafx {
     version = "17.0.8"
     modules = ['javafx.controls']

--- a/controller-app/src/main/java/frc/nemesis/controller/ControllerApp.java
+++ b/controller-app/src/main/java/frc/nemesis/controller/ControllerApp.java
@@ -36,7 +36,7 @@ public class ControllerApp extends Application {
     EventHandler<ActionEvent> buttonHandler = event -> onButtonPress(event);
 
     // Create a Pane for the compass buttons
-Pane compassPane = new Pane();
+    Pane compassPane = new Pane();
 
     // Define the center coordinates and radius
     double centerX = 300;
@@ -82,7 +82,7 @@ Pane compassPane = new Pane();
     // Create the Scene and set it to the stage
     Scene scene = new Scene(root, 600, 600);
     primaryStage.setScene(scene);
-    // primaryStage.setMaximized(true);
+    primaryStage.setFullScreen(true);
 
     // Add the on close handler
     primaryStage.setOnCloseRequest(

--- a/controller-app/src/main/java/frc/nemesis/controller/ControllerApp.java
+++ b/controller-app/src/main/java/frc/nemesis/controller/ControllerApp.java
@@ -1,0 +1,131 @@
+package frc.nemesis.controller;
+
+import java.util.HashMap;
+import java.util.Map;
+import javafx.application.Application;
+import javafx.event.ActionEvent;
+import javafx.event.EventHandler;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Pane;
+import javafx.stage.Stage;
+
+public class ControllerApp extends Application {
+
+  private static final String DEFAULT_BUTTON_STYLE = null;
+  private static final String SELECTED_BUTTON_STYLE = "-fx-background-color: green";
+
+  private final NetworkTableClient client = NetworkTableClient.getInstance();
+
+  private final Map<String, Button> buttonMap = new HashMap<>();
+
+  private static final String[] compassPoints = {"E", "SE", "S", "SW", "W", "NW", "N", "NE"};
+
+  @Override
+  public void start(Stage primaryStage) {
+    primaryStage.setTitle("Nemesis Controller");
+
+    // Create a BorderPane to hold the content
+    BorderPane root = new BorderPane();
+    root.setPadding(new Insets(20));
+
+    EventHandler<ActionEvent> buttonHandler = event -> onButtonPress(event);
+
+    // Create a Pane for the compass buttons
+Pane compassPane = new Pane();
+
+    // Define the center coordinates and radius
+    double centerX = 300;
+    double centerY = 300;
+    double radius = 200;
+
+    // Create and position compass buttons
+    double angleStep = Math.PI / 4; // 45 degrees in radians
+    for (int i = 0; i < compassPoints.length; i++) {
+      double angle = i * angleStep;
+      double x = centerX + radius * Math.cos(angle);
+      double y = centerY + radius * Math.sin(angle);
+
+      Button button = new Button(compassPoints[i]);
+      buttonMap.put(compassPoints[i], button);
+
+      button.setOnAction(buttonHandler);
+
+      button.setPrefWidth(80);
+      button.setPrefHeight(40);
+      button.setLayoutX(x - button.getWidth() / 2);
+      button.setLayoutY(y - button.getHeight() / 2);
+      button.setStyle(DEFAULT_BUTTON_STYLE);
+      compassPane.getChildren().add(button);
+    }
+
+    // Create an HBox for the bottom buttons
+    HBox buttonBox = new HBox(10); // Spacing of 10 between buttons
+    buttonBox.setAlignment(Pos.CENTER); // Center the buttons horizontally
+
+    Button connectButton = new Button("Connect");
+    connectButton.setOnAction(event -> connect());
+
+    Button refreshButton = new Button("Refresh");
+    refreshButton.setOnAction(event -> refresh());
+
+    buttonBox.getChildren().addAll(connectButton, refreshButton);
+
+    // Add the compassPane and buttonBox to the BorderPane
+    root.setCenter(compassPane);
+    root.setBottom(buttonBox);
+
+    // Create the Scene and set it to the stage
+    Scene scene = new Scene(root, 600, 600);
+    primaryStage.setScene(scene);
+    // primaryStage.setMaximized(true);
+
+    // Add the on close handler
+    primaryStage.setOnCloseRequest(
+        event -> {
+          System.out.println("Exiting ...");
+          client.disconnect();
+        });
+
+    primaryStage.show();
+
+    refresh();
+  }
+
+  private void onButtonPress(ActionEvent event) {
+    if (!(event.getSource() instanceof Button)) {
+      return;
+    }
+    Button button = (Button) event.getSource();
+    String buttonText = button.getText();
+    System.out.println("Button Pressed:" + buttonText);
+    client.publish("moveTo", buttonText);
+    refresh();
+  }
+
+  private void refresh() {
+    String moveTo = client.getValue("moveTo");
+    System.out.println("Refresh Pressed: " + moveTo);
+
+    for (Map.Entry<String, Button> entry : buttonMap.entrySet()) {
+      Button button = entry.getValue();
+      if (entry.getKey().equals(moveTo)) {
+        button.setStyle(SELECTED_BUTTON_STYLE);
+      } else {
+        button.setStyle(DEFAULT_BUTTON_STYLE);
+      }
+    }
+  }
+
+  private void connect() {
+    client.connect();
+  }
+
+  public static void main(String[] args) {
+    launch(args);
+  }
+}

--- a/controller-app/src/main/java/frc/nemesis/controller/NetworkTableClient.java
+++ b/controller-app/src/main/java/frc/nemesis/controller/NetworkTableClient.java
@@ -1,0 +1,77 @@
+package frc.nemesis.controller;
+
+import edu.wpi.first.networktables.NetworkTable;
+import edu.wpi.first.networktables.NetworkTableEntry;
+import edu.wpi.first.networktables.NetworkTableInstance;
+import edu.wpi.first.networktables.NetworkTablesJNI;
+import edu.wpi.first.util.CombinedRuntimeLoader;
+import edu.wpi.first.util.WPIUtilJNI;
+import java.io.IOException;
+
+/**
+ * Client for communicating with the Robot and Driver Station through NetworkTables.
+ *
+ * <p>See https://docs.wpilib.org/en/stable/docs/software/networktables/client-side-program.html
+ */
+class NetworkTableClient {
+
+  private static final String TABLE_NAME = "ControllerApp/target";
+
+  private static final NetworkTableClient instance = new NetworkTableClient();
+
+  private final NetworkTableInstance networkTable;
+
+  private NetworkTableClient() {
+    initialize();
+    networkTable = NetworkTableInstance.getDefault();
+    connect();
+  }
+
+  public static final NetworkTableClient getInstance() {
+    return instance;
+  }
+
+  public void connect() {
+    if (networkTable.isConnected()) {
+      // Already connected
+      System.out.println(" -- Already Connected -- ");
+      return;
+    }
+    networkTable.setServer("localhost");
+    networkTable.startClient4("Nemesis Controller");
+    // recommended if running on DS computer; this gets the robot IP from the DS
+    networkTable.startDSClient();
+  }
+
+  public void disconnect() {
+    networkTable.disconnect();
+    networkTable.close();
+  }
+
+  public void publish(String key, String value) {
+    NetworkTableEntry entry = getEntry(key);
+    entry.setString(value);
+    entry.close();
+    networkTable.flush();
+  }
+
+  public String getValue(String key) {
+    return getEntry(key).getString("not found");
+  }
+
+  private NetworkTableEntry getEntry(String key) {
+    connect();
+    NetworkTable table = networkTable.getTable(TABLE_NAME);
+    return table.getEntry(key);
+  }
+
+  private static void initialize() {
+    try {
+      NetworkTablesJNI.Helper.setExtractOnStaticLoad(false);
+      WPIUtilJNI.Helper.setExtractOnStaticLoad(false);
+      CombinedRuntimeLoader.loadLibraries(NetworkTableClient.class, "wpiutiljni", "ntcorejni");
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -28,3 +28,5 @@ pluginManagement {
 
 Properties props = System.getProperties();
 props.setProperty("org.gradle.internal.native.headers.unresolved.dependencies.ignore", "true");
+
+include 'controller-app'

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -50,22 +50,22 @@ public final class Constants {
   private static List<FRCPolygon> polygons = new ArrayList<>();
   private static Rectangle2D fieldBounds = new Rectangle2D.Double(0, 0, 15, 15);
   /*
- * 
- * The ordering of points matters. I went mad trying to debug at one point, turns out it was in a bowtie and not a square
- * Bowtie shape (incorrect rectangle):
- * 
- *     (0,2)---(2,2)
- *      / \   / \
- *     /   \ /   \
- *    (0,0)---(2,0)
- * 
- * Square shape (correct rectangle):
- * 
- *    (0,2)---(2,2)
- *     |       |
- *     |       |
- *    (0,0)---(2,0) 
- */
+   *
+   * The ordering of points matters. I went mad trying to debug at one point, turns out it was in a bowtie and not a square
+   * Bowtie shape (incorrect rectangle):
+   *
+   *     (0,2)---(2,2)
+   *      / \   / \
+   *     /   \ /   \
+   *    (0,0)---(2,0)
+   *
+   * Square shape (correct rectangle):
+   *
+   *    (0,2)---(2,2)
+   *     |       |
+   *     |       |
+   *    (0,0)---(2,0)
+   */
   public static final FRCPolygon playBox =
       new FRCPolygon(
           "playBox",

--- a/src/main/java/frc/robot/subsystems/drive/Drive.java
+++ b/src/main/java/frc/robot/subsystems/drive/Drive.java
@@ -211,7 +211,9 @@ public class Drive extends SubsystemBase {
 
       // Apply update
       poseEstimator.updateWithTime(sampleTimestamps[i], rawGyroRotation, modulePositions);
-      Logger.recordOutput("Odometry/zoneOfField", Constants.locator.getZoneOfField(poseEstimator.getEstimatedPosition()));
+      Logger.recordOutput(
+          "Odometry/zoneOfField",
+          Constants.locator.getZoneOfField(poseEstimator.getEstimatedPosition()));
     }
 
     // Update gyro alert

--- a/src/main/java/frc/robot/util/PolygonLocator.java
+++ b/src/main/java/frc/robot/util/PolygonLocator.java
@@ -30,7 +30,7 @@ public class PolygonLocator {
     return null;
   }
 
-  @AutoLogOutput(key = "Odometry/zoneOfField") // this isn't freaking working 
+  @AutoLogOutput(key = "Odometry/zoneOfField") // this isn't freaking working
   public String getZoneOfField(Pose2d robotPose) {
     if (Constants.locator.findContainingPolygon(robotPose.getTranslation()) != null) {
       return Constants.locator.findContainingPolygon(robotPose.getTranslation()).getName();


### PR DESCRIPTION
This is a simple skeleton implementation of the controller app. Uses JavaFX as UI toolkit and NetworkTables to send values to DriverStation and Robot. 

This required some gradle changes. Need to verify this works on a windows machine and doesn't cause issues with deploying code to Robot before merging into master. The app can be run from the `Gradle Extension -> controller-app -> Tasks -> run`. Alternatively can be run using the gradlew wrapper script from top level project directory:

- Windows: `gradlew.bat controller-app:run`
- Mac/Linux:` ./gradlew controller-app:run`