### PR TITLE
Updates elevator simulation to use actual measurements

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -330,7 +330,10 @@ public class RobotContainer {
                 new IntakeArmIOSim(DCMotor.getFalcon500(1), 4, .1));
         arm = new Arm(new ArmIOSim(DCMotor.getFalcon500(1), 1, 1, 1, 1, 1, true, 1));
         elevator =
-            new Elevator(new ElevatorIOSim(DCMotor.getFalcon500(1), 1, 1, 1, 1, 10, false, 1));
+            new Elevator(
+                // 18T * 5mm pitch * 24:14 gear ratio
+                new ElevatorIOSim(
+                    DCMotor.getFalcon500(1), (24.0 / 14.0), 1, 18 * .005, 0, 4, false, 0));
         endEffector =
             new EndEffector(
                 new EndEffectorIOSim(

--- a/src/main/java/frc/robot/subsystems/elevator/Elevator.java
+++ b/src/main/java/frc/robot/subsystems/elevator/Elevator.java
@@ -110,7 +110,8 @@ public class Elevator extends SubsystemBase {
   }
 
   public double getHeightMeters() {
-    return inputs.rotationCount * 6 / Constants.ElevatorConstantsLeonidas.reduction;
+    // 18T * 5mm pitch * 24:14 gear ratio
+    return inputs.rotationCount * 18 * 0.005 * 24 / 14;
   }
 
   public Translation3d[] getElevatorTranslations() {

--- a/src/main/java/frc/robot/subsystems/elevator/ElevatorIOSim.java
+++ b/src/main/java/frc/robot/subsystems/elevator/ElevatorIOSim.java
@@ -10,7 +10,7 @@ import frc.robot.util.SafetyChecker;
 
 public class ElevatorIOSim implements ElevatorIO {
   private ElevatorSim elevatorSim;
-  private double drumRadiusMeters;
+  private double drumCircumfrenceMeters;
   private double gearing;
   private LoggedTunableNumber cruiseVelocity = new LoggedTunableNumber("Arm/cruiseVelocity", 10);
   private LoggedTunableNumber acceleration = new LoggedTunableNumber("Arm/acceleration", 15);
@@ -25,14 +25,14 @@ public class ElevatorIOSim implements ElevatorIO {
       DCMotor gearbox,
       double gearing,
       double carriageMassKg,
-      double drumRadiusMeters,
+      double drumCircumfrenceMeters,
       double minHeightMeters,
       double maxHeightMeters,
       boolean simulateGravity,
       double startingHeightMeters,
       double... measurementStdDevs) {
     this.gearBox = gearbox;
-    this.drumRadiusMeters = drumRadiusMeters;
+    this.drumCircumfrenceMeters = drumCircumfrenceMeters;
     this.gearing = gearing;
 
     elevatorSim =
@@ -40,7 +40,7 @@ public class ElevatorIOSim implements ElevatorIO {
             gearbox,
             gearing,
             carriageMassKg,
-            drumRadiusMeters,
+            drumCircumfrenceMeters / (2 * Math.PI),
             minHeightMeters,
             maxHeightMeters,
             simulateGravity,
@@ -72,7 +72,7 @@ public class ElevatorIOSim implements ElevatorIO {
     double elevatorPos = this.rotationCount;
 
     if (SafetyChecker.isSafe(SafetyChecker.MechanismType.ELEVATOR_MOVEMENT, elevatorPos)) {
-      double positionMeters = position * 2 * Math.PI * drumRadiusMeters / gearing;
+      double positionMeters = position * drumCircumfrenceMeters / gearing;
       requestedPositionMeters = positionMeters;
       elevatorSim.setState(positionMeters, cruiseVelocity.get());
     } else {
@@ -107,6 +107,6 @@ public class ElevatorIOSim implements ElevatorIO {
   }
 
   private double positionToRotations(double positionMeters) {
-    return positionMeters / (2 * Math.PI * drumRadiusMeters / gearing);
+    return positionMeters / (drumCircumfrenceMeters * gearing);
   }
 }


### PR DESCRIPTION
Leonidas uses an 18T pulley with 5mm pitch, and the gear ratio is 24:14.
Source: https://frc2590.slack.com/archives/CE7S0TBKQ/p1760646852094929

This updates the code to use the real measurements instead of guesses!

Measurements look like they match up with the field:
![elevator_sim](https://github.com/user-attachments/assets/373c1213-d6d8-4209-b02c-04d2efaf8d58)
